### PR TITLE
Configurable Local Host Address

### DIFF
--- a/src/parascale/actor/last/Relay.scala
+++ b/src/parascale/actor/last/Relay.scala
@@ -25,6 +25,8 @@ package parascale.actor.last
 import java.io.ObjectOutputStream
 import java.net.{InetAddress, ServerSocket, Socket}
 
+import parascale.util.getPropertyOrElse
+
 /**
   * This object binds an actor for reply purposes to a destination host.
   * @author Ron.Coleman
@@ -58,7 +60,7 @@ class Relay(forward: String, callback: Actor) extends Actor {
   LOG.info("relaying all messages to "+forwardAddr+":"+forwardPort)
 
   // Initialize reply target
-  val replyAddr =  InetAddress.getLocalHost.getHostAddress
+  val replyAddr = getPropertyOrElse("bindAddr", InetAddress.getLocalHost.getHostAddress)
   val replyPort = forwardPort + Thread.activeCount
   LOG.info("listening for replies on "+replyAddr+":"+replyPort)
 

--- a/src/parascale/actor/last/Task.scala
+++ b/src/parascale/actor/last/Task.scala
@@ -25,6 +25,8 @@ package parascale.actor.last
 import java.io.ObjectOutputStream
 import java.net.{InetAddress, Socket}
 
+import parascale.util.getPropertyOrElse
+
 /** Experimental task enumeration */
 object TaskType extends Enumeration {
   val TASK, REPLY = Value
@@ -34,7 +36,7 @@ object TaskType extends Enumeration {
 object Task {
   val TASK = 0
   val REPLY = 1
-  val LOCAL_HOST = InetAddress.getLocalHost.getHostAddress + ":0"
+  val LOCAL_HOST = getPropertyOrElse("bindAddr", InetAddress.getLocalHost.getHostAddress) + ":0"
 }
 
 /**


### PR DESCRIPTION
This PR adds a JVM parameter, `-DbindAddress` which will cause `Task` and `Relay` to use the parameter value instead of `InetAddress.getLocalHost.getHostAddress` as the host address.

The impetus for this change is that some Linux systems (WSL Debian, and NixOS 20.09) use their loopback as their default network device.  `InetAddress.getLocalHost.getHostAddress` yields `127.0.0.1` on such systems, making multi-host scale out impossible.